### PR TITLE
Documentation with GitHub Pages Deployment

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,29 @@
+name: Deploy mdBook to Github Pages
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.40'
+
+      - run: mdbook build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ yarn-error.log*
 
 # idea files
 .idea
+
+# mdbooks
+/docs/book

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ yarn-error.log*
 .idea
 
 # mdbooks
-/docs/book
+/docs/book/

--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ classDiagram
     Comment --> Post : belongs to
     Notification --> User : notifies
 ```
-
 ## Build Instructions
+
+> [!Important]  
+> Building this project from source requires installing [Git](https://git-scm.com/), [NodeJS](https://nodejs.org/en), and [Docker](https://www.docker.com/products/docker-desktop/).
 
 1. Clone the repository and change into the directory
    ```
@@ -106,7 +108,7 @@ classDiagram
    ```
 2. Create your .env file
    ```
-   Modify .env.example and rename to .env
+   Copy .env.example and rename it to .env
    ```
 3. Install the dependencies
    ```

--- a/book.toml
+++ b/book.toml
@@ -4,4 +4,7 @@ authors = ["Zachary Thomas"]
 description = "This site provides all of the documentation currently available for UCollab."
 language = "en"
 multilingual = false
-src = "src"
+src = "docs/src"
+
+[build]
+build-dir = "docs/book"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,7 @@
+[book]
+title = "UCollab Docs"
+authors = ["Zachary Thomas"]
+description = "This site provides all of the documentation currently available for UCollab."
+language = "en"
+multilingual = false
+src = "src"

--- a/docs/src/01-README.md
+++ b/docs/src/01-README.md
@@ -1,0 +1,1 @@
+# Introduction

--- a/docs/src/02-BUILD.md
+++ b/docs/src/02-BUILD.md
@@ -1,0 +1,1 @@
+# Project

--- a/docs/src/03-BUILD-DOCS.md
+++ b/docs/src/03-BUILD-DOCS.md
@@ -1,0 +1,1 @@
+# Documentation

--- a/docs/src/04-CLASS-DIAGRAM.md
+++ b/docs/src/04-CLASS-DIAGRAM.md
@@ -1,0 +1,1 @@
+# Class Diagram

--- a/docs/src/05-MOCKUPS.md
+++ b/docs/src/05-MOCKUPS.md
@@ -1,0 +1,1 @@
+# Mockups

--- a/docs/src/06-COLOR-SCHEMES.md
+++ b/docs/src/06-COLOR-SCHEMES.md
@@ -1,0 +1,1 @@
+# Color Schemes

--- a/docs/src/07-FEATURES.md
+++ b/docs/src/07-FEATURES.md
@@ -1,0 +1,1 @@
+# Features

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,18 @@
+# Summary
+
+- [Introduction](./01-README.md)
+
+# Build Guide
+
+- [Project](./02-BUILD.md)
+- [Documentation](./03-BUILD-DOCS.md)
+
+# Design Guide
+
+- [Class Diagram](./04-CLASS-DIAGRAM.md)
+- [Mockups](./05-MOCKUPS.md)
+- [Color Schemes](./06-COLOR-SCHEMES.md)
+
+# User Guide
+
+- [Features](./07-FEATURES.md)


### PR DESCRIPTION
Added [mdBook](https://github.com/rust-lang/mdBook) for documentation and a workflow for automated GitHub Pages deployment. Once the repository is setup for support, users should be able to access documentation at [https://steelesh.github.io/UCollab/](https://steelesh.github.io/UCollab/).

Building and serving the docs from source _locally_ requires Rust to be installed. However, collaborators can avoid this by working on documentation locally in a typical markdown editor so they can preview any additions or changes before pushing them to the repo.

Also updated README.md to include build from source prerequisites.